### PR TITLE
Feat/redirection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ async fn main() -> std::io::Result<()> {
     info!("Running on port {}", port);
 
     HttpServer::new(move || {
-        let client = awc::Client::new();
+        let client = awc::Client::builder().disable_redirects().finish();
 
         let cors = Cors::permissive();
 

--- a/src/routes/get_tx_data.rs
+++ b/src/routes/get_tx_data.rs
@@ -35,7 +35,7 @@ pub async fn get_tx_data(
                 }
                 if req.status().is_redirection() {
                     info!("Found {} at {} - redirecting", tx_id, bundler);
-                    let fallback_redir = format!("http://arweave.net/{}", tx_id);
+                    let fallback_redir = format!("https://arweave.net/{}", tx_id);
                     return Ok(HttpResponse::PermanentRedirect()
                         .insert_header((
                             "Location",

--- a/src/routes/index.rs
+++ b/src/routes/index.rs
@@ -1,15 +1,14 @@
-use serde::Serialize;
 use actix_web::HttpResponse;
+use serde::Serialize;
 
 #[derive(Serialize)]
 pub struct IndexResponse {
-    uptime: f32
+    uptime: f32,
 }
 
 pub async fn index() -> actix_web::Result<HttpResponse> {
-    let res = IndexResponse{
-        uptime: psutil::host::uptime().unwrap().as_secs_f32()
+    let res = IndexResponse {
+        uptime: psutil::host::uptime().unwrap().as_secs_f32(),
     };
-    Ok(HttpResponse::Ok()
-        .json(res))
+    Ok(HttpResponse::Ok().json(res))
 }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,4 +1,4 @@
-pub mod index;
 pub mod get_tx_data;
+pub mod index;
 pub mod post_tx;
 pub mod sign_mock;

--- a/src/routes/post_tx.rs
+++ b/src/routes/post_tx.rs
@@ -1,20 +1,17 @@
 use std::cmp::Ordering;
 
-use actix_web::{HttpResponse, web::{Data}};
+use actix_web::{web::Data, HttpResponse};
 use log::{info, trace};
 
 pub async fn post_tx(
     bundlers: Data<Vec<String>>,
-    client: Data<awc::Client>
+    client: Data<awc::Client>,
 ) -> actix_web::Result<HttpResponse> {
     let mut balances = Vec::with_capacity(bundlers.len());
     for bundler in bundlers.iter() {
         let url = format!("{}/tx", bundler);
         // Get balance
-        let request = client
-            .head(&url)
-            .send()
-            .await;
+        let request = client.head(&url).send().await;
 
         trace!("Client has {} balance with {}", 1, bundler);
         balances.push(1);
@@ -36,5 +33,5 @@ pub async fn post_tx(
 
     Ok(HttpResponse::Found()
         .insert_header(("Location", max_bundler.as_str()))
-        .finish())           
+        .finish())
 }

--- a/src/routes/sign_mock.rs
+++ b/src/routes/sign_mock.rs
@@ -1,12 +1,11 @@
-use serde::Serialize;
 use actix_web::HttpResponse;
+use serde::Serialize;
 
 #[derive(Serialize)]
 pub struct IndexResponse {
-    uptime: f32
+    uptime: f32,
 }
 
 pub async fn sign_mock() -> actix_web::Result<HttpResponse> {
-    Ok(HttpResponse::Ok()
-        .body("some signature".as_bytes()))
+    Ok(HttpResponse::Ok().body("some signature".as_bytes()))
 }


### PR DESCRIPTION
This PR adds a redirection response handler for GET /tx/:id/data from nodes, redirecting users to the location returned by the bundler node, or if not specified, the arweave gateway.